### PR TITLE
Hw wdt fix

### DIFF
--- a/esptool/cmds.py
+++ b/esptool/cmds.py
@@ -92,7 +92,7 @@ def detect_chip(
         detect_port.USES_RFC2217 = True
     detect_port.connect(connect_mode, connect_attempts, detecting=True)
     try:
-        print("Detecting chip type...", end="")
+        #print("Detecting chip type...", end="")
         res = detect_port.check_command(
             "get security info", ESPLoader.ESP_GET_SECURITY_INFO, b""
         )
@@ -115,13 +115,13 @@ def detect_chip(
         # UnsupportedCommmanddError: ESP8266/ESP32 ROM
         # struct.error: ESP32-S2
         # FatalError: ESP8266/ESP32 STUB
-        print(" Unsupported detection protocol, switching and trying again...")
+        #print(" Unsupported detection protocol, switching and trying again...")
         try:
             # ESP32/ESP8266 are reset after an unsupported command, need to reconnect
             # (not needed on ESP32-S2)
             if not isinstance(e, struct.error):
                 detect_port.connect(
-                    connect_mode, connect_attempts, detecting=True, warnings=False
+                    "wdt_reset", connect_attempts, detecting=True, warnings=False
                 )
             print("Detecting chip type...", end="")
             sys.stdout.flush()

--- a/esptool/cmds.py
+++ b/esptool/cmds.py
@@ -77,9 +77,7 @@ def detect_chip(
 ):
     """Use serial access to detect the chip type.
 
-    First, get_security_info command is sent to detect the ID of the chip
-    (supported only by ESP32-C3 and later, works even in the Secure Download Mode).
-    If this fails, we reconnect and fall-back to reading the magic number.
+    First, read the magic number.
     It's mapped at a specific ROM address and has a different value on each chip model.
     This way we use one memory read and compare it to the magic number for each chip.
 
@@ -90,56 +88,33 @@ def detect_chip(
     detect_port = ESPLoader(port, baud, trace_enabled=trace_enabled)
     if detect_port.serial_port.startswith("rfc2217:"):
         detect_port.USES_RFC2217 = True
-    detect_port.connect(connect_mode, connect_attempts, detecting=True)
-    try:
-        #print("Detecting chip type...", end="")
-        res = detect_port.check_command(
-            "get security info", ESPLoader.ESP_GET_SECURITY_INFO, b""
-        )
-        # 4b flags, 1b flash_crypt_cnt, 7*1b key_purposes, 4b chip_id
-        res = struct.unpack("<IBBBBBBBBI", res[:16])
-        chip_id = res[9]  # 2/4 status bytes invariant
-
-        for cls in ROM_LIST[3:]:
-            # cmd not supported on ESP8266 and ESP32 + ESP32-S2 doesn't return chip_id
-            if chip_id == cls.IMAGE_CHIP_ID:
-                inst = cls(detect_port._port, baud, trace_enabled=trace_enabled)
-                inst._post_connect()
-                try:
-                    inst.read_reg(
-                        ESPLoader.CHIP_DETECT_MAGIC_REG_ADDR
-                    )  # Dummy read to check Secure Download mode
-                except UnsupportedCommandError:
-                    inst.secure_download_mode = True
-    except (UnsupportedCommandError, struct.error, FatalError) as e:
+    detect_port.connect("wdt_reset", connect_attempts, detecting=True)
         # UnsupportedCommmanddError: ESP8266/ESP32 ROM
         # struct.error: ESP32-S2
         # FatalError: ESP8266/ESP32 STUB
         #print(" Unsupported detection protocol, switching and trying again...")
-        try:
-            # ESP32/ESP8266 are reset after an unsupported command, need to reconnect
-            # (not needed on ESP32-S2)
-            if not isinstance(e, struct.error):
-                detect_port.connect(
-                    "wdt_reset", connect_attempts, detecting=True, warnings=False
-                )
-            print("Detecting chip type...", end="")
-            sys.stdout.flush()
-            chip_magic_value = detect_port.read_reg(
-                ESPLoader.CHIP_DETECT_MAGIC_REG_ADDR
-            )
+    try:
+        # ESP32/ESP8266 are reset after an unsupported command, need to reconnect
+        # (not needed on ESP32-S2)
+        print("Detecting chip type...", end="")
+        sys.stdout.flush()
+        chip_magic_value = detect_port.read_reg(
+            ESPLoader.CHIP_DETECT_MAGIC_REG_ADDR
+        )
 
-            for cls in ROM_LIST:
-                if chip_magic_value in cls.CHIP_DETECT_MAGIC_VALUE:
-                    inst = cls(detect_port._port, baud, trace_enabled=trace_enabled)
-                    inst._post_connect()
-                    inst.check_chip_id()
-        except UnsupportedCommandError:
-            raise FatalError(
-                "Unsupported Command Error received. "
-                "Probably this means Secure Download Mode is enabled, "
-                "autodetection will not work. Need to manually specify the chip."
-            )
+        for cls in ROM_LIST:
+            if chip_magic_value in cls.CHIP_DETECT_MAGIC_VALUE:
+                inst = cls(detect_port._port, baud, trace_enabled=trace_enabled)
+                inst._post_connect()
+                inst.check_chip_id()
+
+    except UnsupportedCommandError:
+        raise FatalError(
+            "Unsupported Command Error received. "
+            "Probably this means Secure Download Mode is enabled, "
+            "autodetection will not work. Need to manually specify the chip."
+        )
+
     finally:
         if inst is not None:
             print(" %s" % inst.CHIP_NAME, end="")

--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -491,6 +491,9 @@ class ESPLoader(object):
     def _set_mysa_WDT_EN(self, state):
         self._setDTR(not state) #inverted logic on serial port IO -> active low
 
+    def _set_mysa_PRG_EN(self, state):
+        self._setRTS(not state) #inverted logic on serial port IO -> active low
+
     def mysa_WDT_reset(self):
         WDT_ENABLE = False     #To assert wdt in enable mode pin is low
         PROGRAM_ENABLE = False #To assert chip in program mode pin is low
@@ -499,7 +502,6 @@ class ESPLoader(object):
         self._set_mysa_WDT_EN(WDT_ENABLE)
 
         time.sleep(2.0)
-
         self._set_mysa_WDT_EN(not WDT_ENABLE)
         time.sleep(0.1) #issue on some cpus -> https://github.com/empoweredhomes/mysa-esp-idf/commit/d2101cd328f1e589e4c6cd9137c029a64b1bbaa7
         self._set_mysa_PRG_EN(not PROGRAM_ENABLE)
@@ -648,7 +650,7 @@ class ESPLoader(object):
                 itertools.cycle((False, True)),
             ):
                 last_error = self._connect_attempt(
-                    mode=mode, usb_jtag_serial=usb_jtag_serial, extra_delay=extra_delay
+                    mode="wdt_reset", usb_jtag_serial=usb_jtag_serial, extra_delay=extra_delay
                 )
                 if last_error is None:
                     break

--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -650,7 +650,7 @@ class ESPLoader(object):
                 itertools.cycle((False, True)),
             ):
                 last_error = self._connect_attempt(
-                    mode="wdt_reset", usb_jtag_serial=usb_jtag_serial, extra_delay=extra_delay
+                    mode=mode, usb_jtag_serial=usb_jtag_serial, extra_delay=extra_delay
                 )
                 if last_error is None:
                     break

--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -488,7 +488,23 @@ class ESPLoader(object):
             "using standard reset sequence.".format(active_port)
         )
 
-    def bootloader_reset(self, usb_jtag_serial=False, extra_delay=False):
+    def _set_mysa_WDT_EN(self, state):
+        self._setDTR(not state) #inverted logic on serial port IO -> active low
+
+    def mysa_WDT_reset(self):
+        WDT_ENABLE = False     #To assert wdt in enable mode pin is low
+        PROGRAM_ENABLE = False #To assert chip in program mode pin is low
+
+        self._set_mysa_PRG_EN(PROGRAM_ENABLE)
+        self._set_mysa_WDT_EN(WDT_ENABLE)
+
+        time.sleep(2.0)
+
+        self._set_mysa_WDT_EN(not WDT_ENABLE)
+        time.sleep(0.1) #issue on some cpus -> https://github.com/empoweredhomes/mysa-esp-idf/commit/d2101cd328f1e589e4c6cd9137c029a64b1bbaa7
+        self._set_mysa_PRG_EN(not PROGRAM_ENABLE)
+
+    def bootloader_reset(self, mode, usb_jtag_serial=False, extra_delay=False):
         """
         Issue a reset-to-bootloader, with USB-JTAG-Serial custom reset sequence option
         """
@@ -516,6 +532,8 @@ class ESPLoader(object):
             time.sleep(0.1)
             self._setDTR(False)
             self._setRTS(False)
+
+        elif mode == 'wdt_reset': self.mysa_WDT_reset()
         else:
             # This fpga delay is for Espressif internal use
             fpga_delay = (
@@ -553,7 +571,7 @@ class ESPLoader(object):
             if not self.USES_RFC2217:  # Might block on rfc2217 ports
                 # Empty serial buffer to isolate boot log
                 self._port.reset_input_buffer()
-            self.bootloader_reset(usb_jtag_serial, extra_delay)
+            self.bootloader_reset(mode, usb_jtag_serial, extra_delay)
 
             # Detect the ROM boot log and check actual boot mode (ESP32 and later only)
             waiting = self._port.inWaiting()


### PR DESCRIPTION
Fixing up the wdt reset function for esptool fixing for the chip detection tool used by port scanning (hard coded to wdt_reset). Defaulting to the magic numbers as get security info isn't supported on our chips (magic numbers should be supported for new ICs though as well)

Fix an incorrect assertion for the program pin. 


