### PR TITLE
Allowing chip_detect and flash to exit into run mode allowing the thermostat to boot

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -600,7 +600,7 @@ class ESPLoader(object):
             print("Allowing device to boot...")
             self._set_mysa_PRG_EN(not PROGRAM_ENABLE)
         
-        time.sleep(2.0) #let the watchdog timer kick the esp if on old green board programmers
+        time.sleep(2.24) #let the watchdog timer kick the esp if on old green board programmers
         self._set_mysa_WDT_EN(not WDT_ENABLE)
 
     def bootloader_reset(self, mode, usb_jtag_serial=False, extra_delay=False):

--- a/esptool.py
+++ b/esptool.py
@@ -588,18 +588,20 @@ class ESPLoader(object):
     def _set_mysa_WDT_EN(self, state):
         self._setDTR(not state) #inverted logic on serial port IO -> active low
 
-    def mysa_WDT_reset(self):
+    def mysa_WDT_reset(self, run_mode=False):
         WDT_ENABLE = False     #To assert wdt in enable mode pin is low
         PROGRAM_ENABLE = False #To assert chip in program mode pin is low
 
         self._set_mysa_PRG_EN(PROGRAM_ENABLE)
-        self._set_mysa_WDT_EN(WDT_ENABLE)
+        self._set_mysa_WDT_EN(WDT_ENABLE) 
+        time.sleep(0.05) #prog and wdt together cause esp to reset on v2.4 ftdi assert pin briefly
 
-        time.sleep(2.0)
-
+        if run_mode: 
+            print("Allowing device to boot...")
+            self._set_mysa_PRG_EN(not PROGRAM_ENABLE)
+        
+        time.sleep(2.0) #let the watchdog timer kick the esp if on old green board programmers
         self._set_mysa_WDT_EN(not WDT_ENABLE)
-        time.sleep(0.1) #issue on some cpus -> https://github.com/empoweredhomes/mysa-esp-idf/commit/d2101cd328f1e589e4c6cd9137c029a64b1bbaa7
-        self._set_mysa_PRG_EN(not PROGRAM_ENABLE)
 
     def bootloader_reset(self, mode, usb_jtag_serial=False, extra_delay=False):
         """ Issue a reset-to-bootloader, with USB-JTAG-Serial custom reset sequence option
@@ -1330,9 +1332,9 @@ class ESPLoader(object):
         time.sleep(0.1)
         self._setRTS(False)
 
-    def wdt_reset(self):
+    def wdt_reset(self, run_mode=False):
         print("Using Mysa WDT to reset...")
-        self.mysa_WDT_reset()
+        self.mysa_WDT_reset(run_mode=run_mode)
 
     def soft_reset(self, stay_in_bootloader):
         if not self.IS_STUB:
@@ -5028,7 +5030,7 @@ def main(argv=None, esp=None):
         elif args.after == 'hard_reset':
             esp.hard_reset()
         elif args.after == 'wdt_reset':
-            esp.wdt_reset()
+            esp.wdt_reset(run_mode=True)
         elif args.after == 'soft_reset':
             print('Soft resetting...')
             # flash_finish will trigger a soft reset

--- a/esptool/cmds.py
+++ b/esptool/cmds.py
@@ -88,7 +88,8 @@ def detect_chip(
     detect_port = ESPLoader(port, baud, trace_enabled=trace_enabled)
     if detect_port.serial_port.startswith("rfc2217:"):
         detect_port.USES_RFC2217 = True
-    detect_port.connect("wdt_reset", connect_attempts, detecting=True)
+    detect_port.mysa_WDT_reset()
+    detect_port.connect("no_reset", connect_attempts, detecting=True)
         # UnsupportedCommmanddError: ESP8266/ESP32 ROM
         # struct.error: ESP32-S2
         # FatalError: ESP8266/ESP32 STUB
@@ -96,7 +97,7 @@ def detect_chip(
     try:
         # ESP32/ESP8266 are reset after an unsupported command, need to reconnect
         # (not needed on ESP32-S2)
-        print("Detecting chip type...", end="")
+        print("Detecting chip type...\n", end="")
         sys.stdout.flush()
         chip_magic_value = detect_port.read_reg(
             ESPLoader.CHIP_DETECT_MAGIC_REG_ADDR
@@ -116,6 +117,7 @@ def detect_chip(
         )
 
     finally:
+        detect_port.mysa_WDT_reset(run_mode=True)
         if inst is not None:
             print(" %s" % inst.CHIP_NAME, end="")
             if detect_port.sync_stub_detected:
@@ -127,7 +129,6 @@ def detect_chip(
         "Unexpected CHIP magic value 0x%08x. Failed to autodetect chip type."
         % (chip_magic_value)
     )
-
 
 # "Operation" commands, executable at command line. One function each
 #

--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -506,7 +506,7 @@ class ESPLoader(object):
             print("Allowing device to boot...")
             self._set_mysa_PRG_EN(not PROGRAM_ENABLE)
         
-        time.sleep(2.0) #let the watchdog timer kick the esp if on old green board programmers
+        time.sleep(2.24) #let the watchdog timer kick the esp if on old green board programmers
         self._set_mysa_WDT_EN(not WDT_ENABLE)
 
     def bootloader_reset(self, mode, usb_jtag_serial=False, extra_delay=False):

--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -489,10 +489,10 @@ class ESPLoader(object):
         )
 
     def _set_mysa_WDT_EN(self, state):
-        self._setDTR(not state) 
+        self._setDTR(not state) #inverted logic on serial port IO -> active low
 
     def _set_mysa_PRG_EN(self, state):
-        self._setRTS(not state) 
+        self._setRTS(not state) #inverted logic on serial port IO -> active low 
 
     def mysa_WDT_reset(self, run_mode=False):
         WDT_ENABLE = False     #To assert wdt in enable mode pin is low

--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -489,22 +489,25 @@ class ESPLoader(object):
         )
 
     def _set_mysa_WDT_EN(self, state):
-        self._setDTR(not state) #inverted logic on serial port IO -> active low
+        self._setDTR(not state) 
 
     def _set_mysa_PRG_EN(self, state):
-        self._setRTS(not state) #inverted logic on serial port IO -> active low
+        self._setRTS(not state) 
 
-    def mysa_WDT_reset(self):
+    def mysa_WDT_reset(self, run_mode=False):
         WDT_ENABLE = False     #To assert wdt in enable mode pin is low
         PROGRAM_ENABLE = False #To assert chip in program mode pin is low
 
         self._set_mysa_PRG_EN(PROGRAM_ENABLE)
-        self._set_mysa_WDT_EN(WDT_ENABLE)
-
-        time.sleep(2.0)
+        self._set_mysa_WDT_EN(WDT_ENABLE) 
+        time.sleep(0.05) #prog and wdt together cause esp to reset on v2.4 ftdi assert pin briefly
+        
+        if run_mode: 
+            print("Allowing device to boot...")
+            self._set_mysa_PRG_EN(not PROGRAM_ENABLE)
+        
+        time.sleep(2.0) #let the watchdog timer kick the esp if on old green board programmers
         self._set_mysa_WDT_EN(not WDT_ENABLE)
-        time.sleep(0.1) #issue on some cpus -> https://github.com/empoweredhomes/mysa-esp-idf/commit/d2101cd328f1e589e4c6cd9137c029a64b1bbaa7
-        self._set_mysa_PRG_EN(not PROGRAM_ENABLE)
 
     def bootloader_reset(self, mode, usb_jtag_serial=False, extra_delay=False):
         """


### PR DESCRIPTION
# Description of change
Allowing chip_detect and flash to exit into run mode allowing the thermostat to boot

# This change fixes the following bug(s):
Issue highlighted by Rob when launching idf.py menuconfig

# I have tested this change with the following hardware & software combinations:
David and I have tested the following:

BB2L, INF with either v2.4 programmer or old programmer using mysa_thermostat repo:

idf.py flash -> flashes, boots into loaded firmware
idf.py monitor -> resets device, opens monitor, boots into loaded firmware
idf.py flash monitor ->  flashes, boots into loaded firmware, opens monitor
idf.py -p _port_ monitor -> does not reset device, opens monitor
idf.py -p _port_ flash  -> flashes, boots into loaded firmware
idf.py -p _port_ flash monitor -> flashes, boots into loaded firmware, opens monitor
