### PR TITLE
Make espefuse.py work with python3.10

### DIFF
--- a/espefuse/efuse/base_fields.py
+++ b/espefuse/efuse/base_fields.py
@@ -27,9 +27,13 @@ class CheckArgValue(object):
             if efuse.efuse_type.startswith("bool"):
                 new_value = 1 if new_value is None else int(new_value, 0)
                 if new_value != 1:
-                    raise esptool.FatalError("New value is not accepted for efuse '{}' (will always burn 0->1), given value={}"
-                                             .format(efuse.name, new_value))
-            elif efuse.efuse_type.startswith(('int', 'uint')):
+                    raise esptool.FatalError(
+                        "New value is not accepted for efuse '{}' "
+                        "(will always burn 0->1), given value={}".format(
+                            efuse.name, new_value
+                        )
+                    )
+            elif efuse.efuse_type.startswith(("int", "uint")):
                 if efuse.efuse_class == "bitcount":
                     if new_value is None:
                         # find the first unset bit and set it
@@ -43,18 +47,36 @@ class CheckArgValue(object):
                         new_value = int(new_value, 0)
                 else:
                     if new_value is None:
-                        raise esptool.FatalError("New value required for efuse '{}' (given None)".format(efuse.name))
+                        raise esptool.FatalError(
+                            "New value required for efuse '{}' (given None)".format(
+                                efuse.name
+                            )
+                        )
                     new_value = int(new_value, 0)
                     if new_value == 0:
-                        raise esptool.FatalError("New value should not be 0 for '{}' (given value= {})".format(efuse.name, new_value))
+                        raise esptool.FatalError(
+                            "New value should not be 0 for '{}' "
+                            "(given value= {})".format(efuse.name, new_value)
+                        )
             elif efuse.efuse_type.startswith("bytes"):
                 if new_value is None:
-                    raise esptool.FatalError("New value required for efuse '{}' (given None)".format(efuse.name))
+                    raise esptool.FatalError(
+                        "New value required for efuse '{}' "
+                        "(given None)".format(efuse.name)
+                    )
                 if len(new_value) * 8 != efuse.bitarray.len:
-                    raise esptool.FatalError("The length of efuse '{}' ({} bits) (given len of the new value= {} bits)"
-                                             .format(efuse.name, efuse.bitarray.len, len(new_value) * 8))
+                    raise esptool.FatalError(
+                        "The length of efuse '{}' ({} bits) "
+                        "(given len of the new value= {} bits)".format(
+                            efuse.name, efuse.bitarray.len, len(new_value) * 8
+                        )
+                    )
             else:
-                raise esptool.FatalError("The '{}' type for the '{}' efuse is not supported yet.".format(efuse.efuse_type, efuse.name))
+                raise esptool.FatalError(
+                    "The '{}' type for the '{}' efuse is not supported yet.".format(
+                        efuse.efuse_type, efuse.name
+                    )
+                )
             return new_value
 
         efuse = self.efuses[self.name]

--- a/espefuse/efuse/base_operations.py
+++ b/espefuse/efuse/base_operations.py
@@ -10,7 +10,7 @@ import argparse
 import json
 import sys
 
-from bitstring import BitString
+from bitstring import BitStream
 
 import esptool
 
@@ -627,7 +627,7 @@ def burn_bit(esp, efuses, args):
     efuses.force_write_always = args.force_write_always
     num_block = efuses.get_index_block_by_name(args.block)
     block = efuses.blocks[num_block]
-    data_block = BitString(block.get_block_len() * 8)
+    data_block = BitStream(block.get_block_len() * 8)
     data_block.set(0)
     try:
         data_block.set(True, args.bit_number)

--- a/espefuse/efuse/emulate_efuse_controller_base.py
+++ b/espefuse/efuse/emulate_efuse_controller_base.py
@@ -10,12 +10,6 @@ import re
 
 from bitstring import BitStream
 
-try:
-    FileNotFoundError
-except NameError:
-    # Python 2.7 compatibility
-    FileNotFoundError = IOError
-
 
 class EmulateEfuseControllerBase(object):
     """The class for virtual efuse operations. Using for HOST_TEST."""
@@ -33,16 +27,16 @@ class EmulateEfuseControllerBase(object):
         if self.efuse_file:
             try:
                 self.mem = BitStream(
-                    bytes=open(self.efuse_file, "rb").read(),
-                    length=self.REGS.EFUSE_MEM_SIZE * 8,
+                    open(self.efuse_file, "a+b"), length=self.REGS.EFUSE_MEM_SIZE * 8
                 )
-            except (ValueError, FileNotFoundError):
+            except ValueError:
                 # the file is empty or does not fit the length.
                 self.mem = BitStream(length=self.REGS.EFUSE_MEM_SIZE * 8)
                 self.mem.set(0)
                 self.mem.tofile(open(self.efuse_file, "a+b"))
         else:
-            # efuse_file is not provided it means we do not want to keep the result of efuse operations
+            # efuse_file is not provided
+            #  it means we do not want to keep the result of efuse operations
             self.mem = BitStream(self.REGS.EFUSE_MEM_SIZE * 8)
             self.mem.set(0)
 
@@ -209,7 +203,9 @@ class EmulateEfuseControllerBase(object):
                     ):
                         raw_data = self.read_field(field.name)
                         raw_data.set(0)
-                        block.pos = block.length - (field.word * 32 + field.pos + raw_data.length)
+                        block.pos = block.length - (
+                            field.word * 32 + field.pos + raw_data.length
+                        )
                         block.overwrite(BitStream(raw_data.length))
             self.overwrite_mem_from_block(blk, block)
 

--- a/espefuse/efuse/esp32c2/emulate_efuse_controller.py
+++ b/espefuse/efuse/esp32c2/emulate_efuse_controller.py
@@ -6,8 +6,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from __future__ import division, print_function
-
 from bitstring import BitStream
 
 import reedsolo
@@ -137,6 +135,8 @@ class EmulateEfuseController(EmulateEfuseControllerBase):
                     ):
                         raw_data = self.read_field(field.name)
                         raw_data.set(0)
-                        block.pos = block.length - (field.word * 32 + field.pos + raw_data.length)
+                        block.pos = block.length - (
+                            field.word * 32 + field.pos + raw_data.length
+                        )
                         block.overwrite(BitStream(raw_data.length))
             self.overwrite_mem_from_block(blk, block)


### PR DESCRIPTION
updating efuse code to work with python3.10 or some new version of bitstring.

(Please delete any lines which don't apply)

# Description of change

# This change fixes the following bug(s):

(Please put issue URLs or #number-of-issue here.)

# I have tested this change with the following hardware & software combinations:

(Operating system(s), development board name(s), ESP8266 and/or ESP32.)

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

(Details here: https://docs.espressif.com/projects/esptool/en/latest/contributing.html#automated-integration-tests)
